### PR TITLE
Correction of download URL for trained models

### DIFF
--- a/Defocus_Deblurring/pretrained_models/README.md
+++ b/Defocus_Deblurring/pretrained_models/README.md
@@ -1,1 +1,1 @@
-pre-trained defocus deblurring model is available [here](https://github.com/swz30/MIRNetv2/releases/download/v1.0.0/dual_pixel_defocus_deblurring.pth)
+pre-trained defocus deblurring model is available [here](https://github.com/swz30/MIRNetv2/releases/tag/v1.0.0)

--- a/Enhancement/pretrained_models/README.md
+++ b/Enhancement/pretrained_models/README.md
@@ -1,1 +1,1 @@
-pre-trained deblurring model is available [here](https://drive.google.com/drive/folders/1czMyfRTQDX3j3ErByYeZ1PM4GVLbJeGK?usp=sharing)
+pre-trained deblurring model is available [here](https://github.com/swz30/MIRNetv2/releases/tag/v1.0.0)


### PR DESCRIPTION
- Unify the URLs from which the four types of trained models are downloaded.
- The deblurring model is corrected because the URL was incorrect.